### PR TITLE
Add Metadata File for PSCommFooterControllerTest

### DIFF
--- a/PSCommFooterControllerTest.cls-meta.xml
+++ b/PSCommFooterControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Deployments are failing to new orgs because the src is missing a metadata file for the controller test class. Adding metadata file to address this issue.